### PR TITLE
Fix: extensions/bluez-firmware.sh repo path

### DIFF
--- a/extensions/bluez-firmware.sh
+++ b/extensions/bluez-firmware.sh
@@ -3,7 +3,7 @@ function fetch_sources_tools__bluez_firmware() {
 }
 
 function post_family_tweaks__install_bluez_firmware() {
-    cp "${SRC}"/cache/sources/bluez-firmware-git/broadcom/BCM4345C0.hcd "${SDCARD}"/lib/firmware/brcm/BCM4345C0.hcd
+    cp "${SRC}"/cache/sources/bluez-firmware/broadcom/BCM4345C0.hcd "${SDCARD}"/lib/firmware/brcm/BCM4345C0.hcd
     cp "${SDCARD}"/lib/firmware/brcm/brcmfmac43455-sdio.txt "${SDCARD}"/lib/firmware/brcm/brcmfmac43455-sdio.phicomm,n1.txt
     cp "${SDCARD}"/lib/firmware/brcm/brcmfmac43455-sdio.bin "${SDCARD}"/lib/firmware/brcm/brcmfmac43455-sdio.phicomm,n1.bin
 }


### PR DESCRIPTION
# Description
fix bluez-firmware clone path mismatch 


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
